### PR TITLE
Fix split regex issue on autosuggest helper

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -23,8 +23,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 32
-        versionCode 3119
-        versionName "3.1.19"
+        versionCode 3120
+        versionName "3.1.20"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/lib/maven-push.gradle
+++ b/lib/maven-push.gradle
@@ -2,7 +2,7 @@ def ossrhUsername = findProperty('OSSRH_USERNAME')
 def ossrhPassword = findProperty('OSSRH_PASSWORD')
 def signingKey = findProperty('SIGNING_KEY')
 def signingKeyPwd = findProperty('SIGNING_KEY_PWD')
-def libVersion = findProperty('LIBRARY_VERSION') ? findProperty('LIBRARY_VERSION') : "3.1.19"
+def libVersion = findProperty('LIBRARY_VERSION') ? findProperty('LIBRARY_VERSION') : "3.1.20"
 
 task androidSourcesJar(type: Jar) {
     archiveClassifier.convention('sources')

--- a/lib/src/main/java/com/what3words/androidwrapper/helpers/AutosuggestHelper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/helpers/AutosuggestHelper.kt
@@ -7,10 +7,13 @@ import com.what3words.javawrapper.request.SourceApi
 import com.what3words.javawrapper.response.APIResponse
 import com.what3words.javawrapper.response.Suggestion
 import com.what3words.javawrapper.response.SuggestionWithCoordinates
+import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import com.what3words.javawrapper.What3WordsV3.didYouMean3wa
+import com.what3words.javawrapper.What3WordsV3.isPossible3wa
 
 class AutosuggestHelper(
     private val api: What3WordsV3,
@@ -36,12 +39,12 @@ class AutosuggestHelper(
     ) {
         var isDidYouMean = false
         val searchFiltered: String? = when {
-            searchText.isPossible3wa() -> searchText
-            !allowFlexibleDelimiters && searchText.didYouMean3wa() -> {
+            isPossible3wa(searchText) -> searchText
+            !allowFlexibleDelimiters && didYouMean3wa(searchText) -> {
                 isDidYouMean = true
                 searchText.split(splitRegex, 3).joinToString(".")
             }
-            allowFlexibleDelimiters && searchText.didYouMean3wa() -> searchText.split(
+            allowFlexibleDelimiters && didYouMean3wa(searchText) -> searchText.split(
                 splitRegex,
                 3
             ).joinToString(".")
@@ -76,7 +79,7 @@ class AutosuggestHelper(
             CoroutineScope(dispatchers.main()).launch {
                 if (res.isSuccessful) {
                     if (isDidYouMean) {
-                        res.suggestions.firstOrNull { it.words == finalQuery }?.let {
+                        res.suggestions.firstOrNull { it.words.lowercase(Locale.getDefault()) == finalQuery.lowercase(Locale.getDefault()) }?.let {
                             onDidYouMeanListener?.accept(it)
                         }
                     } else {

--- a/lib/src/main/java/com/what3words/androidwrapper/helpers/Extensions.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/helpers/Extensions.kt
@@ -2,7 +2,7 @@ package com.what3words.androidwrapper.helpers
 
 import java.util.regex.Pattern
 
-internal val splitRegex = Regex("[.｡。･・︒។։။۔።।,-_/ ]+")
+internal val splitRegex = Regex("[.｡。･・︒។։။۔።। ,\\\\^_/+'&\\:;|　-]+")
 
 @Deprecated("", ReplaceWith("com.what3words.javawrapper.What3WordsV3.isPossible3wa()"))
 fun String.isPossible3wa(): Boolean {


### PR DESCRIPTION
- split regex was out of date and didn't work if uppercase was used.
- needed to force lowercase before comparing strings.
- remove deprecated usage of the regex functions (using java-wrapper ones now).