### PR TITLE
updated VoiceProvider interface initialize method

### DIFF
--- a/lib/src/main/java/com/what3words/androidwrapper/helpers/Extensions.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/helpers/Extensions.kt
@@ -22,12 +22,16 @@ fun String.didYouMean3wa(): Boolean {
     }
 }
 
-@Deprecated("",  ReplaceWith("com.what3words.javawrapper.What3WordsV3.searchPossible3wa()"))
+@Deprecated("", ReplaceWith("com.what3words.javawrapper.What3WordsV3.searchPossible3wa()"))
 fun String.searchPossible3wa(): List<String> {
     val searchRegex =
         "(?:\\p{L}\\p{M}*){1,}[.｡。･・︒។։။۔።।](?:\\p{L}\\p{M}*){1,}[.｡。･・︒។։။۔።।](?:\\p{L}\\p{M}*){1,}"
     Regex(searchRegex).also {
         return it.findAll(this).map { it.value }.toList()
     }
+}
+
+internal operator fun StringBuilder.plusAssign(other: String) {
+    append(other)
 }
 

--- a/lib/src/main/java/com/what3words/androidwrapper/voice/VoiceBuilderWithCoordinates.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/voice/VoiceBuilderWithCoordinates.kt
@@ -4,7 +4,7 @@ import androidx.core.util.Consumer
 import com.what3words.androidwrapper.What3WordsAndroidWrapper
 import com.what3words.androidwrapper.helpers.DefaultDispatcherProvider
 import com.what3words.androidwrapper.helpers.DispatcherProvider
-import com.what3words.androidwrapper.voice.VoiceApi.Companion.URL_WITH_COORDINATES
+import com.what3words.javawrapper.request.AutosuggestOptions
 import com.what3words.javawrapper.request.BoundingBox
 import com.what3words.javawrapper.request.Coordinates
 import com.what3words.javawrapper.response.APIError
@@ -19,14 +19,7 @@ class VoiceBuilderWithCoordinates(
     private val voiceLanguage: String,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider()
 ) : VoiceApiListenerWithCoordinates {
-    private var clipToPolygon: Array<Coordinates>? = null
-    private var clipToBoundingBox: BoundingBox? = null
-    private var clipToCircle: Coordinates? = null
-    private var clipToCircleRadius: Double? = null
-    private var clipToCountry: Array<String>? = null
-    private var nFocusResults: Int? = null
-    private var focus: Coordinates? = null
-    private var nResults: Int? = null
+    internal var autosuggestOptions: AutosuggestOptions = AutosuggestOptions()
     private var onSuggestionsCallback: Consumer<List<SuggestionWithCoordinates>>? = null
     private var onErrorCallback: Consumer<APIResponse.What3WordsError>? = null
     private var isListening = false
@@ -90,9 +83,10 @@ class VoiceBuilderWithCoordinates(
     fun startListening(): VoiceBuilderWithCoordinates {
         isListening = true
         api.voiceProvider.initialize(
-            mic.recordingRate,
-            mic.encoding,
-            url = createSocketUrlWithCoordinates(api.voiceProvider.baseUrl),
+            sampleRate = mic.recordingRate,
+            encoding = mic.encoding,
+            autosuggestOptions = autosuggestOptions,
+            voiceLanguage = voiceLanguage,
             listener = this
         )
         return this
@@ -126,7 +120,7 @@ class VoiceBuilderWithCoordinates(
      * @return a [VoiceBuilderWithCoordinates] instance
      */
     fun focus(coordinates: Coordinates?): VoiceBuilderWithCoordinates {
-        focus = coordinates
+        autosuggestOptions.focus = coordinates
         return this
     }
 
@@ -138,7 +132,7 @@ class VoiceBuilderWithCoordinates(
      * @return a [VoiceBuilderWithCoordinates] instance
      */
     fun nResults(n: Int?): VoiceBuilderWithCoordinates {
-        nResults = n ?: 3
+        autosuggestOptions.nResults = n ?: 3
         return this
     }
 
@@ -152,7 +146,7 @@ class VoiceBuilderWithCoordinates(
      * @return a [VoiceBuilderWithCoordinates] instance
      */
     fun nFocusResults(n: Int?): VoiceBuilderWithCoordinates {
-        nFocusResults = n
+        autosuggestOptions.nFocusResults = n
         return this
     }
 
@@ -168,8 +162,8 @@ class VoiceBuilderWithCoordinates(
         centre: Coordinates?,
         radius: Double? = 1.0
     ): VoiceBuilderWithCoordinates {
-        clipToCircle = centre
-        clipToCircleRadius = radius
+        autosuggestOptions.clipToCircle = centre
+        autosuggestOptions.clipToCircleRadius = radius
         return this
     }
 
@@ -183,7 +177,7 @@ class VoiceBuilderWithCoordinates(
      * @return a [VoiceBuilderWithCoordinates] instance
      */
     fun clipToCountry(countryCodes: List<String>): VoiceBuilderWithCoordinates {
-        clipToCountry = if (countryCodes.isNotEmpty()) countryCodes.toTypedArray() else null
+        autosuggestOptions.clipToCountry = if (countryCodes.isNotEmpty()) countryCodes else null
         return this
     }
 
@@ -196,7 +190,7 @@ class VoiceBuilderWithCoordinates(
     fun clipToBoundingBox(
         boundingBox: BoundingBox?
     ): VoiceBuilderWithCoordinates {
-        clipToBoundingBox = boundingBox
+        autosuggestOptions.clipToBoundingBox = boundingBox
         return this
     }
 
@@ -211,35 +205,19 @@ class VoiceBuilderWithCoordinates(
     fun clipToPolygon(
         polygon: List<Coordinates>
     ): VoiceBuilderWithCoordinates {
-        clipToPolygon = if (polygon.isNotEmpty()) polygon.toTypedArray() else null
+        autosuggestOptions.clipToPolygon = if (polygon.isNotEmpty()) polygon else null
         return this
     }
 
-    internal fun createSocketUrlWithCoordinates(baseUrl: String): String {
-        var url = "${baseUrl}${URL_WITH_COORDINATES}"
-        url += if (voiceLanguage == "zh") "?voice-language=cmn"
-        else "?voice-language=$voiceLanguage"
-        nResults?.let {
-            url += "&n-results=$nResults"
-        }
-        focus?.let {
-            url += "&focus=${focus!!.lat},${focus!!.lng}"
-            if (nFocusResults != null) {
-                url += "&n-focus-results=$nFocusResults"
-            }
-        }
-        clipToCountry?.let {
-            url += "&clip-to-country=${it.joinToString(",")}"
-        }
-        clipToCircle?.let {
-            url += "&clip-to-circle=${it.lat},${it.lng},${clipToCircleRadius ?: 1}"
-        }
-        clipToPolygon?.let {
-            url += "&clip-to-polygon=${it.joinToString(",") { "${it.lat},${it.lng}" }}"
-        }
-        clipToBoundingBox?.let {
-            url += "&clip-to-bounding-box=${it.sw.lat},${it.sw.lng},${it.ne.lat},${it.ne.lng}"
-        }
-        return url
+    /**
+     * This method allows for updating the autosuggest options of the [VoiceBuilderWithCoordinates]
+     * instance by setting the autosuggestOptions property to the provided options.
+     *
+     * @param options The new AutosuggestOptions to be set.
+     * @return The updated [VoiceBuilderWithCoordinates] object.
+     */
+    fun updateAutosuggestOptions(options: AutosuggestOptions): VoiceBuilderWithCoordinates {
+        this.autosuggestOptions = options
+        return this
     }
 }

--- a/lib/src/test/java/com/what3words/androidwrapper/VoiceApiTests.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/VoiceApiTests.kt
@@ -6,16 +6,22 @@ import com.what3words.androidwrapper.voice.VoiceApi
 import com.what3words.androidwrapper.voice.VoiceApi.Companion.BASE_URL
 import com.what3words.androidwrapper.voice.VoiceApiListener
 import com.what3words.androidwrapper.voice.VoiceApiListenerWithCoordinates
+import com.what3words.javawrapper.request.AutosuggestOptions
+import com.what3words.javawrapper.request.BoundingBox
+import com.what3words.javawrapper.request.Coordinates
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.test.runBlockingTest
 import okhttp3.OkHttpClient
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import org.junit.Before
 import org.junit.Test
+import java.lang.Exception
+import com.google.common.truth.Truth.assertThat
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -93,7 +99,7 @@ class VoiceApiTests {
             true
         }
 
-        voiceApi = VoiceApi("any", "any", mockClient)
+        voiceApi = VoiceApi("any", BASE_URL, mockClient)
     }
 
     private fun mockWebSocket(
@@ -165,7 +171,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listener
         )
         mockWebSocket.send("voice1")
@@ -194,7 +201,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listenerWithCoordinates
         )
         mockWebSocket.send("voice1")
@@ -223,7 +231,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listener
         )
         mockWebSocket.close(1003, jsonError)
@@ -246,7 +255,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listenerWithCoordinates
         )
         mockWebSocket.close(1003, jsonError)
@@ -269,7 +279,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listener
         )
         mockWebSocket.close(1003, jsonError)
@@ -292,7 +303,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listenerWithCoordinates
         )
         mockWebSocket.close(1003, jsonError)
@@ -315,7 +327,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listener
         )
         mockWebSocket.send("voice1")
@@ -342,7 +355,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listenerWithCoordinates
         )
         mockWebSocket.send("voice1")
@@ -369,7 +383,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             6,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listener
         )
         mockWebSocket.send("voice1")
@@ -396,7 +411,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listenerWithCoordinates
         )
         mockWebSocket.send("voice1")
@@ -423,7 +439,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listener
         )
         mockWebSocket.send("voice1")
@@ -450,7 +467,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listenerWithCoordinates
         )
         mockWebSocket.send("voice1")
@@ -477,7 +495,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_FLOAT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listener
         )
 
@@ -502,7 +521,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_8BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listenerWithCoordinates
         )
 
@@ -528,7 +548,8 @@ class VoiceApiTests {
         voiceApi.initialize(
             Microphone.DEFAULT_RECORDING_RATE,
             AudioFormat.ENCODING_PCM_16BIT,
-            BASE_URL,
+            "en",
+            AutosuggestOptions(),
             listener
         )
         mockWebSocket.send("voice1")
@@ -543,5 +564,28 @@ class VoiceApiTests {
         }
         verify(exactly = 0) { listener.error(any()) }
         assert(voiceApi.socket == null)
+    }
+
+    @Test
+    fun `createSocketUrl with AutosuggestOptions matches expected param url`() {
+        // given
+        val expectedUrl =
+            "${BASE_URL}${VoiceApi.URL_WITHOUT_COORDINATES}?voice-language=en&clip-to-polygon=51.1,-0.152,51.1,-0.152,51.1,-0.152&clip-to-bounding-box=51.1,-0.152,51.1,-0.152"
+
+        // when
+        val actualUrl =
+            voiceApi.createSocketUrl(url = "${BASE_URL}${VoiceApi.URL_WITHOUT_COORDINATES}",
+                voiceLanguage = "en", autosuggestOptions = AutosuggestOptions().apply {
+                    clipToBoundingBox =
+                        BoundingBox(Coordinates(51.1, -0.152), Coordinates(51.1, -0.152))
+
+                    clipToPolygon = listOf(
+                        Coordinates(51.1, -0.152),
+                        Coordinates(51.1, -0.152),
+                        Coordinates(51.1, -0.152)
+                    )
+                })
+
+        assertThat(actualUrl).contains(expectedUrl)
     }
 }

--- a/lib/src/test/java/com/what3words/androidwrapper/VoiceBuilderTests.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/VoiceBuilderTests.kt
@@ -11,6 +11,7 @@ import com.what3words.androidwrapper.voice.VoiceApi
 import com.what3words.androidwrapper.voice.VoiceApi.Companion.BASE_URL
 import com.what3words.androidwrapper.voice.VoiceApi.Companion.URL_WITHOUT_COORDINATES
 import com.what3words.androidwrapper.voice.VoiceApiListener
+import com.what3words.javawrapper.request.AutosuggestOptions
 import com.what3words.javawrapper.request.BoundingBox
 import com.what3words.javawrapper.request.Coordinates
 import com.what3words.javawrapper.response.APIError
@@ -66,7 +67,7 @@ class VoiceBuilderTests {
 
         justRun {
             voiceApi.forceStop()
-            voiceApi.initialize(any(), any(), any(), any<VoiceApiListener>())
+            voiceApi.initialize(any(), any(), any(), any(), any<VoiceApiListener>())
             microphone.startRecording(voiceApi)
             microphone.stopRecording()
             suggestionsCallback.accept(any())
@@ -114,7 +115,7 @@ class VoiceBuilderTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), builder) }
+            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), any(), builder) }
             verify(exactly = 1) { microphone.startRecording(voiceApi) }
 
             // when forced stop
@@ -142,7 +143,7 @@ class VoiceBuilderTests {
 
         // then
         assertThat(builder.isListening()).isTrue()
-        verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), builder) }
+        verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), any(), builder) }
         verify(exactly = 1) { microphone.startRecording(voiceApi) }
 
         // when
@@ -172,7 +173,7 @@ class VoiceBuilderTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), builder) }
+            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), any(), builder) }
             verify(exactly = 1) { microphone.startRecording(voiceApi) }
 
             val suggestionsJson =
@@ -192,28 +193,28 @@ class VoiceBuilderTests {
         }
 
     @Test
-    fun `focus is set expect param url`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        // given
-        val expectedUrl = "${BASE_URL}${URL_WITHOUT_COORDINATES}?voice-language=en&focus=51.1,-0.152"
-        val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
-        val builder = what3WordsV3.autosuggest(microphone, "en")
-            .onSuggestions(suggestionsCallback)
-            .onError(errorCallback)
-
-        // when
-        builder.focus(Coordinates(51.1, -0.152))
-            .startListening()
-
-        // then
-        assertThat(builder.isListening()).isTrue()
-        verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
-    }
-
-    @Test
-    fun `focus is set with nFocusResults expect param url`() =
+    fun `focus is set to VoiceBuilder autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl = "${BASE_URL}${URL_WITHOUT_COORDINATES}?voice-language=en&focus=51.1,-0.152&n-focus-results=3"
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val builder = what3WordsV3.autosuggest(microphone, "en")
+                .onSuggestions(suggestionsCallback)
+                .onError(errorCallback)
+
+            // when
+            builder.focus(Coordinates(51.1, -0.152))
+                .startListening()
+
+            // then
+            assertThat(builder.isListening()).isTrue()
+            assertThat(builder.autosuggestOptions.focus).isEqualTo(Coordinates(51.1, -0.152))
+        }
+
+    @Test
+    fun `focus is set with nFocusResults to VoiceBuilder autosuggestOptions`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggest(microphone, "en")
@@ -226,31 +227,32 @@ class VoiceBuilderTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.focus).isEqualTo(Coordinates(51.1, -0.152))
+            assertThat(builder.autosuggestOptions.nFocusResults).isEqualTo(3)
         }
 
     @Test
-    fun `nResults is set expect param url`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        // given
-        val expectedUrl = "${BASE_URL}${URL_WITHOUT_COORDINATES}?voice-language=en&n-results=3"
-        val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
-        val builder = what3WordsV3.autosuggest(microphone, "en")
-            .onSuggestions(suggestionsCallback)
-            .onError(errorCallback)
-
-        // when
-        builder.nResults(3).startListening()
-
-        // then
-        assertThat(builder.isListening()).isTrue()
-        verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
-    }
-
-    @Test
-    fun `clipToCountry is set expect param url`() =
+    fun `nResults is set to VoiceBuilder autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl = "${BASE_URL}${URL_WITHOUT_COORDINATES}?voice-language=en&clip-to-country=GB,FR"
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val builder = what3WordsV3.autosuggest(microphone, "en")
+                .onSuggestions(suggestionsCallback)
+                .onError(errorCallback)
+
+            // when
+            builder.nResults(3).startListening()
+
+            // then
+            assertThat(builder.isListening()).isTrue()
+            assertThat(builder.autosuggestOptions.nResults).isEqualTo(3)
+        }
+
+    @Test
+    fun `clipToCountry is set to VoiceBuilder autosuggestOptions`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggest(microphone, "en")
@@ -262,14 +264,13 @@ class VoiceBuilderTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToCountry).isEqualTo(listOf("GB", "FR"))
         }
 
     @Test
-    fun `clipToCircle is set without radius expect param url`() =
+    fun `clipToCircle is set without radius to VoiceBuilder autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl = "${BASE_URL}${URL_WITHOUT_COORDINATES}?voice-language=en&clip-to-circle=51.1,-0.152,1.0"
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggest(microphone, "en")
@@ -281,14 +282,14 @@ class VoiceBuilderTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToCircle).isEqualTo(Coordinates(51.1, -0.152))
+            assertThat(builder.autosuggestOptions.clipToCircleRadius).isEqualTo(1.0)
         }
 
     @Test
-    fun `clipToCircle is set with radius expect param url`() =
+    fun `clipToCircle is set with radius to VoiceBuilder autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl = "${BASE_URL}${URL_WITHOUT_COORDINATES}?voice-language=en&clip-to-circle=51.1,-0.152,100.0"
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggest(microphone, "en")
@@ -300,11 +301,12 @@ class VoiceBuilderTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToCircle).isEqualTo(Coordinates(51.1, -0.152))
+            assertThat(builder.autosuggestOptions.clipToCircleRadius).isEqualTo(100.0)
         }
 
     @Test
-    fun `clipToBoundingBox is set expect param url`() =
+    fun `clipToBoundingBox is set to VoiceBuilder autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
             val expectedUrl =
@@ -322,15 +324,18 @@ class VoiceBuilderTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToBoundingBox).isEqualTo(
+                BoundingBox(
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152)
+                )
+            )
         }
 
     @Test
-    fun `clipToPolygon is set expect param url`() =
+    fun `clipToPolygon is set to VoiceBuilder autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl =
-                "${BASE_URL}${URL_WITHOUT_COORDINATES}?voice-language=en&clip-to-polygon=51.1,-0.152,51.1,-0.152,51.1,-0.152"
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggest(microphone, "en")
@@ -348,7 +353,49 @@ class VoiceBuilderTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToPolygon).isEqualTo(
+                listOf(
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152)
+                )
+            )
+        }
+
+    @Test
+    fun `updateAutosuggestOptions in VoiceBuilder`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val builder = what3WordsV3.autosuggest(microphone, "en")
+                .onSuggestions(suggestionsCallback)
+                .onError(errorCallback)
+
+            // when
+            builder.updateAutosuggestOptions(
+                options = AutosuggestOptions().apply {
+                    clipToBoundingBox =
+                        BoundingBox(Coordinates(51.1, -0.152), Coordinates(51.1, -0.152))
+                    clipToPolygon = listOf(
+                        Coordinates(51.1, -0.152),
+                        Coordinates(51.1, -0.152),
+                        Coordinates(51.1, -0.152)
+                    )
+                }
+            ).startListening()
+
+            // then
+            assertThat(builder.isListening()).isTrue()
+            assertThat(builder.autosuggestOptions.clipToPolygon).isEqualTo(
+                listOf(
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152)
+                )
+            )
+            assertThat(builder.autosuggestOptions.clipToBoundingBox).isEqualTo(
+                BoundingBox(Coordinates(51.1, -0.152), Coordinates(51.1, -0.152))
+            )
         }
 
     @Test
@@ -362,7 +409,11 @@ class VoiceBuilderTests {
 
             // when
             val builder = what3WordsV3.autosuggest(microphone, "en")
-            val finalURL = builder.createSocketUrl(what3WordsV3.voiceProvider.baseUrl)
+            val finalURL = (what3WordsV3.voiceProvider as VoiceApi).createSocketUrl(
+                "${what3WordsV3.voiceProvider.baseUrl}${URL_WITHOUT_COORDINATES}",
+                "en",
+                builder.autosuggestOptions
+            )
 
             // then
             assertThat(finalURL.contains(voiceCustomUrl)).isTrue()

--- a/lib/src/test/java/com/what3words/androidwrapper/VoiceBuilderWithCoordinatesTests.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/VoiceBuilderWithCoordinatesTests.kt
@@ -11,6 +11,7 @@ import com.what3words.androidwrapper.voice.VoiceApi
 import com.what3words.androidwrapper.voice.VoiceApi.Companion.BASE_URL
 import com.what3words.androidwrapper.voice.VoiceApi.Companion.URL_WITH_COORDINATES
 import com.what3words.androidwrapper.voice.VoiceApiListenerWithCoordinates
+import com.what3words.javawrapper.request.AutosuggestOptions
 import com.what3words.javawrapper.request.BoundingBox
 import com.what3words.javawrapper.request.Coordinates
 import com.what3words.javawrapper.response.APIError
@@ -66,7 +67,7 @@ class VoiceBuilderWithCoordinatesTests {
 
         justRun {
             voiceApi.forceStop()
-            voiceApi.initialize(any(), any(), any(), any<VoiceApiListenerWithCoordinates>())
+            voiceApi.initialize(any(), any(), any(), any(), any<VoiceApiListenerWithCoordinates>())
             microphone.startRecording(voiceApi)
             microphone.stopRecording()
             suggestionsCallback.accept(any())
@@ -103,7 +104,8 @@ class VoiceBuilderWithCoordinatesTests {
     fun `startListening then force stopListening`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
             builder.onSuggestions(suggestionsCallback)
             builder.onError(errorCallback)
@@ -114,7 +116,7 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), builder) }
+            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), any(), builder) }
             verify(exactly = 1) { microphone.startRecording(voiceApi) }
 
             // when forced stop
@@ -132,7 +134,8 @@ class VoiceBuilderWithCoordinatesTests {
     fun `startListening then error occurs`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
             builder.onSuggestions(suggestionsCallback)
             builder.onError(errorCallback)
@@ -143,7 +146,7 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), builder) }
+            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), any(), builder) }
             verify(exactly = 1) { microphone.startRecording(voiceApi) }
 
             // when
@@ -161,7 +164,8 @@ class VoiceBuilderWithCoordinatesTests {
     fun `startListening then returns suggestions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
             builder.onSuggestions(suggestionsCallback)
             builder.onError(errorCallback)
@@ -172,7 +176,7 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), builder) }
+            verify(exactly = 1) { voiceApi.initialize(any(), any(), any(), any(), builder) }
             verify(exactly = 1) { microphone.startRecording(voiceApi) }
 
             val suggestionsJson =
@@ -193,11 +197,11 @@ class VoiceBuilderWithCoordinatesTests {
         }
 
     @Test
-    fun `focus is set expect param url`() =
+    fun `focus is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl = "${BASE_URL}${URL_WITH_COORDINATES}?voice-language=en&focus=51.1,-0.152"
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
                 .onSuggestions(suggestionsCallback)
                 .onError(errorCallback)
@@ -208,16 +212,15 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.focus).isEqualTo(Coordinates(51.1, -0.152))
         }
 
     @Test
-    fun `focus is set with nFocusResults expect param url`() =
+    fun `focus is set with nFocusResults to VoiceBuilderWithCoordinates autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl =
-                "${BASE_URL}${URL_WITH_COORDINATES}?voice-language=en&focus=51.1,-0.152&n-focus-results=3"
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
                 .onSuggestions(suggestionsCallback)
                 .onError(errorCallback)
@@ -228,15 +231,16 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.focus).isEqualTo(Coordinates(51.1, -0.152))
+            assertThat(builder.autosuggestOptions.nFocusResults).isEqualTo(3)
         }
 
     @Test
-    fun `nResults is set expect param url`() =
+    fun `nResults is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl = "${BASE_URL}${URL_WITH_COORDINATES}?voice-language=en&n-results=3"
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
                 .onSuggestions(suggestionsCallback)
                 .onError(errorCallback)
@@ -246,15 +250,15 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.nResults).isEqualTo(3)
         }
 
     @Test
-    fun `clipToCountry is set expect param url`() =
+    fun `clipToCountry is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl = "${BASE_URL}${URL_WITH_COORDINATES}?voice-language=en&clip-to-country=GB,FR"
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
                 .onSuggestions(suggestionsCallback)
                 .onError(errorCallback)
@@ -264,16 +268,15 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToCountry).isEqualTo(listOf("GB", "FR"))
         }
 
     @Test
-    fun `clipToCircle is set without radius expect param url`() =
+    fun `clipToCircle is set without radius to VoiceBuilderWithCoordinates autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl =
-                "${BASE_URL}${URL_WITH_COORDINATES}?voice-language=en&clip-to-circle=51.1,-0.152,1.0"
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
                 .onSuggestions(suggestionsCallback)
                 .onError(errorCallback)
@@ -283,16 +286,16 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToCircle).isEqualTo(Coordinates(51.1, -0.152))
+            assertThat(builder.autosuggestOptions.clipToCircleRadius).isEqualTo(1.0)
         }
 
     @Test
-    fun `clipToCircle is set with radius expect param url`() =
+    fun `clipToCircle is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl =
-                "${BASE_URL}${URL_WITH_COORDINATES}?voice-language=en&clip-to-circle=51.1,-0.152,100.0"
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
                 .onSuggestions(suggestionsCallback)
                 .onError(errorCallback)
@@ -302,16 +305,16 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToCircle).isEqualTo(Coordinates(51.1, -0.152))
+            assertThat(builder.autosuggestOptions.clipToCircleRadius).isEqualTo(100.0)
         }
 
     @Test
-    fun `clipToBoundingBox is set expect param url`() =
+    fun `clipToBoundingBox is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl =
-                "${BASE_URL}${URL_WITH_COORDINATES}?voice-language=en&clip-to-bounding-box=51.1,-0.152,51.1,-0.152"
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
                 .onSuggestions(suggestionsCallback)
                 .onError(errorCallback)
@@ -323,16 +326,20 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToBoundingBox).isEqualTo(
+                BoundingBox(
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152)
+                )
+            )
         }
 
     @Test
-    fun `clipToPolygon is set expect param url`() =
+    fun `clipToPolygon is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // given
-            val expectedUrl =
-                "${BASE_URL}${URL_WITH_COORDINATES}?voice-language=en&clip-to-polygon=51.1,-0.152,51.1,-0.152,51.1,-0.152"
-            val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
                 .onSuggestions(suggestionsCallback)
                 .onError(errorCallback)
@@ -348,7 +355,49 @@ class VoiceBuilderWithCoordinatesTests {
 
             // then
             assertThat(builder.isListening()).isTrue()
-            verify(exactly = 1) { voiceApi.initialize(any(), any(), expectedUrl, builder) }
+            assertThat(builder.autosuggestOptions.clipToPolygon).isEqualTo(
+                listOf(
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152)
+                )
+            )
+        }
+
+    @Test
+    fun `updateAutosuggestOptions in VoiceBuilderWithCoordinates`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            val what3WordsV3 =
+                What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
+            val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
+                .onSuggestions(suggestionsCallback)
+                .onError(errorCallback)
+
+            // when
+            builder.updateAutosuggestOptions(
+                options = AutosuggestOptions().apply {
+                    clipToBoundingBox =
+                        BoundingBox(Coordinates(51.1, -0.152), Coordinates(51.1, -0.152))
+                    clipToPolygon = listOf(
+                        Coordinates(51.1, -0.152),
+                        Coordinates(51.1, -0.152),
+                        Coordinates(51.1, -0.152)
+                    )
+                }
+            ).startListening()
+
+            // then
+            assertThat(builder.isListening()).isTrue()
+            assertThat(builder.autosuggestOptions.clipToPolygon).isEqualTo(
+                listOf(
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152),
+                    Coordinates(51.1, -0.152)
+                )
+            )
+            assertThat(builder.autosuggestOptions.clipToBoundingBox).isEqualTo(
+                BoundingBox(Coordinates(51.1, -0.152), Coordinates(51.1, -0.152))
+            )
         }
 
     @Test
@@ -362,8 +411,11 @@ class VoiceBuilderWithCoordinatesTests {
 
             // when
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
-            val finalURL = builder.createSocketUrlWithCoordinates(what3WordsV3.voiceProvider.baseUrl)
-
+            val finalURL = (what3WordsV3.voiceProvider as VoiceApi).createSocketUrl(
+                "${what3WordsV3.voiceProvider.baseUrl}${URL_WITH_COORDINATES}",
+                "en",
+                builder.autosuggestOptions
+            )
             // then
             assertThat(finalURL.contains(voiceCustomUrl)).isTrue()
         }


### PR DESCRIPTION
- Modified the `initialize` method of the VoiceProvider interface by replacing the `url` parameter with `voiceLanguage` and `autosuggestOptions` parameters to allow other VoiceProviders to customize autosuggest requests more easily.
- Shifted the responsibility of creating the web socket URL from the VoiceBuilder/VoiceBuilderWithCoordinate classes to the VoiceAPI class.
- Updated the unit tests for VoiceAPI, VoiceBuilder, and VoiceBuilderWithCoordinates to reflect the modifications made on the VoiceProvider interface.