### PR TITLE
Convert Microphone member method to static

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To obtain an API key, please visit [https://what3words.com/select-plan](https://
 ### Gradle
 
 ```
-implementation 'com.what3words:w3w-android-wrapper:3.1.22'
+implementation 'com.what3words:w3w-android-wrapper:3.1.23'
 ```
 
 ## Documentation

--- a/lib/src/main/java/com/what3words/androidwrapper/voice/Microphone.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/voice/Microphone.kt
@@ -18,10 +18,37 @@ class Microphone {
         const val ENCODING = AudioFormat.ENCODING_PCM_16BIT
         const val AUDIO_SOURCE = MediaRecorder.AudioSource.MIC
 
+        /**
+         * Retrieves the optimal sample rate based on the preferred sample rate.
+         * If the preferred sample rate is valid, it is returned as the optimal rate.
+         * Otherwise, the maximum supported sample rate is returned.
+         * @param preferredSampleRate The preferred sample rate to consider.
+         *
+         * @return The optimal sample rate.
+         */
+        fun getOptimalSampleRate(preferredSampleRate: Int): Int {
+            return if (isSampleRateValid(preferredSampleRate)) {
+                preferredSampleRate
+            } else {
+                getSupportedSampleRates().maxOrNull() ?: -1
+            }
+        }
+
+        /**
+         * Checks if the provided sample rate is valid or supported.
+         *
+         * @param sampleRate The sample rate to validate.
+         * @return `true` if the sample rate is valid, `false` otherwise.
+         */
         fun isSampleRateValid(sampleRate: Int): Boolean {
             return getSupportedSampleRates().contains(sampleRate)
         }
 
+        /**
+         * Retrieves a list of supported sample rates for audio recording.
+         *
+         * @return A list of supported sample rates.
+         */
         fun getSupportedSampleRates(): List<Int> {
             val validSampleRates = intArrayOf(
                 8000, 11025, 16000, 22050, 44100, 48000

--- a/lib/src/main/java/com/what3words/androidwrapper/voice/Microphone.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/voice/Microphone.kt
@@ -17,6 +17,28 @@ class Microphone {
         const val CHANNEL = AudioFormat.CHANNEL_IN_DEFAULT
         const val ENCODING = AudioFormat.ENCODING_PCM_16BIT
         const val AUDIO_SOURCE = MediaRecorder.AudioSource.MIC
+
+        fun isSampleRateValid(sampleRate: Int): Boolean {
+            return getSupportedSampleRates().contains(sampleRate)
+        }
+
+        fun getSupportedSampleRates(): List<Int> {
+            val validSampleRates = intArrayOf(
+                8000, 11025, 16000, 22050, 44100, 48000
+            )
+            val list = mutableListOf<Int>()
+            validSampleRates.forEach {
+                val result = AudioRecord.getMinBufferSize(
+                    it,
+                    AudioFormat.CHANNEL_IN_DEFAULT,
+                    AudioFormat.ENCODING_PCM_16BIT
+                )
+                if (result != AudioRecord.ERROR && result != AudioRecord.ERROR_BAD_VALUE && result > 0) {
+                    list.add(it)
+                }
+            }
+            return list
+        }
     }
 
     constructor() {
@@ -30,27 +52,6 @@ class Microphone {
         )
     }
 
-    private fun getSupportedSampleRates(): List<Int> {
-        val validSampleRates = intArrayOf(
-            8000, 11025, 16000, 22050, 44100, 48000
-        )
-        val list = mutableListOf<Int>()
-        validSampleRates.forEach {
-            val result = AudioRecord.getMinBufferSize(
-                it,
-                AudioFormat.CHANNEL_IN_DEFAULT,
-                AudioFormat.ENCODING_PCM_16BIT
-            )
-            if (result != AudioRecord.ERROR && result != AudioRecord.ERROR_BAD_VALUE && result > 0) {
-                list.add(it)
-            }
-        }
-        return list
-    }
-
-    private fun isSampleRateValid(sampleRate: Int): Boolean {
-        return getSupportedSampleRates().contains(sampleRate)
-    }
 
     constructor(recordingRate: Int, encoding: Int, channel: Int, audioSource: Int) {
         this.recordingRate = recordingRate


### PR DESCRIPTION
Converted Microphone.kt `isSampleRateValid` and `getSupportedSampleRates` member methods to static so that clients can use the methods to check if a sampleRate is supported by the audio hardware and also get supported sample rates without creating an instance of the Microphone class.