### PR TITLE
revised config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,22 +3,30 @@ orbs:
   gradle: circleci/gradle@2.2.0
   android: circleci/android@2.3.0
 
+commands:
+  library-setup:
+    description: Restore cache, config gradlew, download dependencies and save cache
+    steps:
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "lib/build.gradle" }}
+      - run:
+          name: Set up library dependencies
+          command: |
+            ./gradlew wrapper
+            ./gradlew lib:androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "lib/build.gradle" }}
 jobs:
-  build-android-test:
+  android-test:
     executor:
       name: android/android-machine
       resource-class: large
       tag: 2023.05.1
     steps:
       - checkout
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "lib/build.gradle" }}
-      - run:
-          name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
-          command: sudo chmod +x ./gradlew
-      - run:
-          name: Wrapper
-          command: ./gradlew wrapper
+      - library-setup
       - android/create-avd:
           avd-name: testDevice
           system-image: system-images;android-30;google_apis;x86
@@ -28,39 +36,18 @@ jobs:
           no-window: true
           post-emulator-launch-assemble-command: echo "Emulator Started"
       - run:
-          name: Download Dependencies
-          command: ./gradlew androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "lib/build.gradle" }}
-      - run:
           name: Run Android Tests
           command: ./gradlew lib:connectedDebugAndroidTest
       - store_test_results:
           path: lib/build/outputs/androidTest-results
-  build-test-sonar:
+  test-sonar:
     docker:
       - image: circleci/android:api-30
     environment:
       JVM_OPTS: -Xmx3200m
     steps:
       - checkout
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "lib/build.gradle" }}
-      - run:
-          name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
-          command: sudo chmod +x ./gradlew
-      - run:
-          name: Wrapper
-          command: ./gradlew wrapper
-      - run:
-          name: Download Dependencies
-          command: ./gradlew androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "lib/build.gradle" }}
+      - library-setup
       - run:
           name: Run Tests
           command: ./gradlew lib:testDebugUnitTest jacocoTestReport sonarqube
@@ -73,21 +60,7 @@ jobs:
       JVM_OPTS: -Xmx3200m
     steps:
       - checkout
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "lib/build.gradle" }}
-      - run:
-          name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
-          command: sudo chmod +x ./gradlew
-      - run:
-          name: Wrapper
-          command: ./gradlew wrapper
-      - run:
-          name: Download Dependencies
-          command: ./gradlew androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "lib/build.gradle" }}
+      - library-setup
       - run:
           name: Inject Maven signing key
           command: |
@@ -114,22 +87,17 @@ jobs:
           path: sample-multi-autosuggest-providers/build/outputs/apk/release
 
 workflows:
-  build-test-sonar:
+  build-test-sonar-publish:
     jobs:
-      - build-test-sonar:
-          name: Build, run tests, upload to sonar
+      - android-test
+      - test-sonar:
           context:
             - SonarCloud
             - mobile
-  build-test-sonar-publish:
-    jobs:
-      - build-android-test
-      - build-test-sonar:
-          context: SonarCloud
       - deploy-to-sonatype:
-          name: Build, run tests, sonar and push to maven staging
+          name: Deploy to sonatype and build sample apps
           requires:
-            - build-test-sonar
+            - test-sonar
           context:
             - mobile
             - maven-sign


### PR DESCRIPTION
- Reusability: Refactored restore cache, dependencies download and save cache steps into the `library-setup` command to reduce steps duplication across jobs and ensure the configuration is easier to maintain. 
- Removed `sudo chmod +x ./gradlew` step as the `./gradlew' script has been granted executable permissions locally.
- Replaced `build-android-test` and `build-test-sonar` jobs with more descriptive names