### PR TITLE
Add new send data method in android wrapper voice provider

### DIFF
--- a/lib/src/main/java/com/what3words/androidwrapper/voice/Microphone.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/voice/Microphone.kt
@@ -153,7 +153,7 @@ class Microphone {
                     audioRecord.startRecording()
                     while (isListening) {
                         val readCount = audioRecord.read(buffer, 0, buffer.size)
-                        provider.sendData(convertAudioRecordToByteString(readCount, buffer))
+                        provider.sendData(readCount, buffer)
                         if ((System.currentTimeMillis() - oldTimestamp) > 100) {
                             oldTimestamp = System.currentTimeMillis()
                             val volume = calculateVolume(readCount, buffer)
@@ -191,13 +191,5 @@ class Microphone {
             volume = 10 * log10(amplitude)
         }
         return volume
-    }
-
-    internal fun convertAudioRecordToByteString(readCount: Int, buffer: ShortArray): ByteString {
-        val bufferBytes: ByteBuffer =
-            ByteBuffer.allocate(readCount * 2) // 2 bytes per short
-        bufferBytes.order(ByteOrder.LITTLE_ENDIAN) // save little-endian byte from short buffer
-        bufferBytes.asShortBuffer().put(buffer, 0, readCount)
-        return ByteString.of(*bufferBytes.array())
     }
 }

--- a/lib/src/main/java/com/what3words/androidwrapper/voice/VoiceApi.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/voice/VoiceApi.kt
@@ -56,6 +56,7 @@ interface VoiceProvider {
     )
 
     fun sendData(byteString: ByteString)
+    fun sendData(readCount: Int, buffer: ShortArray)
 
     fun forceStop()
     var baseUrl: String
@@ -173,6 +174,14 @@ open class VoiceApi(
 
     override fun sendData(byteString: ByteString) {
         socket?.send(byteString)
+    }
+
+    override fun sendData(readCount: Int, buffer: ShortArray) {
+        val bufferBytes: ByteBuffer =
+            ByteBuffer.allocate(readCount * 2) // 2 bytes per short
+        bufferBytes.order(ByteOrder.LITTLE_ENDIAN) // save little-endian byte from short buffer
+        bufferBytes.asShortBuffer().put(buffer, 0, readCount)
+        socket?.send(ByteString.of(*bufferBytes.array()))
     }
 
     /**


### PR DESCRIPTION
I noticed a change in the `VoiceProvider` API last month. The update replaced the parameter of the VoiceProvider's `sendData` method from a ShortArray to a ByteString. While this change aligns with the VoiceAPI endpoint, it poses a challenge for other VoiceProviders that work directly with a ShortArray.

To address this, I added a `sendData` method in the VoiceProvider interface that accepts a `readCount` and `ShortArray` as inputs 