### PR TITLE
Allow 'lines' attribute in GridSectionResponse to be nullable.

### DIFF
--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/GridSectionResponseMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/GridSectionResponseMapper.kt
@@ -9,9 +9,9 @@ import com.what3words.core.types.geometry.W3WLine
 internal class GridSectionResponseMapper(private val lineDtoToDomainMapper: Mapper<LineDto, W3WLine>) :
     Mapper<GridSectionResponse, W3WGridSection> {
     override fun mapFrom(from: GridSectionResponse): W3WGridSection {
-        val lines = from.lines.map { line: LineDto ->
+        val lines = from.lines?.map { line: LineDto ->
             lineDtoToDomainMapper.mapFrom(line)
-        }
+        } ?: emptyList()
         return W3WGridSection(
             lines = lines
         )

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/response/GridSectionResponse.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/response/GridSectionResponse.kt
@@ -4,6 +4,6 @@ import com.what3words.androidwrapper.datasource.text.api.dto.ErrorDto
 import com.what3words.androidwrapper.datasource.text.api.dto.LineDto
 
 internal data class GridSectionResponse(
-    val lines: List<LineDto>,
+    val lines: List<LineDto>?,
     override val error: ErrorDto?
 ): APIResponse


### PR DESCRIPTION
- Allow `lines` attribute in `GridSectionResponse` to be nullable for enhanced flexibility.