### PR TITLE
Refactor code to reflect changes in core library

### DIFF
--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/di/MappersFactory.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/di/MappersFactory.kt
@@ -19,7 +19,7 @@ import com.what3words.core.types.domain.W3WAddress
 import com.what3words.core.types.domain.W3WSuggestion
 import com.what3words.core.types.geometry.W3WCoordinates
 import com.what3words.core.types.geometry.W3WGridSection
-import com.what3words.core.types.language.W3WLanguage
+import com.what3words.core.types.language.W3WProprietaryLanguage
 
 internal object MappersFactory {
     // Lazy delegates to create mapper instances only when they are accessed
@@ -69,7 +69,7 @@ internal object MappersFactory {
     fun providesGridSectionResponseMapper(): Mapper<GridSectionResponse, W3WGridSection> =
         gridSectionResponseMapper
 
-    fun providesAvailableLanguagesResponseMapper(): Mapper<AvailableLanguagesResponse, Set<W3WLanguage>> =
+    fun providesAvailableLanguagesResponseMapper(): Mapper<AvailableLanguagesResponse, Set<W3WProprietaryLanguage>> =
         availableLanguagesResponseMapper
 
     fun providesAutosuggestResponseMapper(): Mapper<AutosuggestResponse, List<W3WSuggestion>> =

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/error/InvalidKeyError.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/error/InvalidKeyError.kt
@@ -1,7 +1,7 @@
 package com.what3words.androidwrapper.datasource.text.api.error
 
 /**
- * Error indicating that an invalid API key was used to initialize the [com.what3words.androidwrapper.datasource.text.W3WApiTextDatasource] class.
+ * Error indicating that an invalid API key was used to initialize the [com.what3words.androidwrapper.datasource.text.W3WApiTextDataSource] class.
  *
  * This error typically occurs when the provided API key does not match the expected format or is not valid for accessing the what3words API.
  *

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/AutosuggestResponseMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/AutosuggestResponseMapper.kt
@@ -11,7 +11,7 @@ import com.what3words.core.types.domain.W3WSuggestion
 import com.what3words.core.types.geometry.W3WCoordinates
 import com.what3words.core.types.geometry.W3WDistance
 import com.what3words.core.types.geometry.W3WRectangle
-import com.what3words.core.types.language.W3WLanguage
+import com.what3words.core.types.language.W3WProprietaryLanguage
 
 internal class AutosuggestResponseMapper(
     private val coordinatesDtoToDomainMapper: Mapper<CoordinatesDto, W3WCoordinates>,
@@ -31,7 +31,7 @@ internal class AutosuggestResponseMapper(
                     square = suggestion.square?.let {
                         squareDtoToDomainMapper.mapFrom(it)
                     },
-                    language = W3WLanguage(suggestion.language, suggestion.locale),
+                    language = W3WProprietaryLanguage(suggestion.language, suggestion.locale),
                     country = W3WCountry(suggestion.country)
                 ),
                 distanceToFocus = suggestion.distanceToFocusKm?.toDouble()?.let(::W3WDistance),

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/AvailableLanguagesResponseMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/AvailableLanguagesResponseMapper.kt
@@ -3,12 +3,12 @@ package com.what3words.androidwrapper.datasource.text.api.mappers
 import com.what3words.androidwrapper.common.Mapper
 import com.what3words.androidwrapper.datasource.text.api.dto.LanguageDto
 import com.what3words.androidwrapper.datasource.text.api.response.AvailableLanguagesResponse
-import com.what3words.core.types.language.W3WLanguage
+import com.what3words.core.types.language.W3WProprietaryLanguage
 
 internal class AvailableLanguagesResponseMapper(
-    private val languageDtoToDomainMapper: Mapper<LanguageDto, List<W3WLanguage>>
-) : Mapper<AvailableLanguagesResponse, Set<W3WLanguage>> {
-    override fun mapFrom(from: AvailableLanguagesResponse): Set<W3WLanguage> {
+    private val languageDtoToDomainMapper: Mapper<LanguageDto, List<W3WProprietaryLanguage>>
+) : Mapper<AvailableLanguagesResponse, Set<W3WProprietaryLanguage>> {
+    override fun mapFrom(from: AvailableLanguagesResponse): Set<W3WProprietaryLanguage> {
         return buildSet {
             from.languages.forEach { language: LanguageDto ->
                 addAll(languageDtoToDomainMapper.mapFrom(language))

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/ConvertTo3waResponseMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/ConvertTo3waResponseMapper.kt
@@ -1,14 +1,14 @@
 package com.what3words.androidwrapper.datasource.text.api.mappers
 
 import com.what3words.androidwrapper.common.Mapper
-import com.what3words.androidwrapper.datasource.text.api.response.ConvertTo3waResponse
 import com.what3words.androidwrapper.datasource.text.api.dto.CoordinatesDto
 import com.what3words.androidwrapper.datasource.text.api.dto.SquareDto
+import com.what3words.androidwrapper.datasource.text.api.response.ConvertTo3waResponse
 import com.what3words.core.types.domain.W3WAddress
 import com.what3words.core.types.domain.W3WCountry
 import com.what3words.core.types.geometry.W3WCoordinates
 import com.what3words.core.types.geometry.W3WRectangle
-import com.what3words.core.types.language.W3WLanguage
+import com.what3words.core.types.language.W3WProprietaryLanguage
 
 internal class ConvertTo3waResponseMapper(
     private val coordinatesDtoToDomainMapper: Mapper<CoordinatesDto, W3WCoordinates>,
@@ -22,7 +22,7 @@ internal class ConvertTo3waResponseMapper(
             val square = square?.let { squareDtoToDomainMapper.mapFrom(it) }
                 ?: throw NullPointerException("Square property cannot be null")
             val language = language?.let {
-                W3WLanguage(code = it, locale = locale)
+                W3WProprietaryLanguage(code = it, locale = locale)
             } ?: throw NullPointerException("Language property cannot be null")
             val country = country?.let { W3WCountry(twoLetterCode = it) }
                 ?: throw NullPointerException("Country property cannot be null")

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/LanguageDtoToDomainMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/LanguageDtoToDomainMapper.kt
@@ -2,20 +2,20 @@ package com.what3words.androidwrapper.datasource.text.api.mappers
 
 import com.what3words.androidwrapper.common.Mapper
 import com.what3words.androidwrapper.datasource.text.api.dto.LanguageDto
-import com.what3words.core.types.language.W3WLanguage
+import com.what3words.core.types.language.W3WProprietaryLanguage
 
-internal class LanguageDtoToDomainMapper : Mapper<LanguageDto, List<W3WLanguage>> {
-    override fun mapFrom(from: LanguageDto): List<W3WLanguage> {
+internal class LanguageDtoToDomainMapper : Mapper<LanguageDto, List<W3WProprietaryLanguage>> {
+    override fun mapFrom(from: LanguageDto): List<W3WProprietaryLanguage> {
         return buildList {
             if (from.locales.isNullOrEmpty()) {
                 add(
-                    W3WLanguage(
+                    W3WProprietaryLanguage(
                         code = from.code, locale = null
                     )
                 )
             } else {
                 addAll(from.locales.map { localeDto ->
-                    W3WLanguage(
+                    W3WProprietaryLanguage(
                         code = from.code, locale = localeDto.code
                     )
                 })

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/W3WApiTextDataSourceTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/W3WApiTextDataSourceTest.kt
@@ -8,16 +8,16 @@ import com.what3words.androidwrapper.datasource.text.fake.FakeWhat3WordsV3Servic
 import com.what3words.core.types.common.W3WResult
 import com.what3words.core.types.geometry.W3WCoordinates
 import com.what3words.core.types.geometry.W3WRectangle
-import com.what3words.core.types.language.W3WLanguage
-import com.what3words.core.types.language.W3WLanguageRCF5646
+import com.what3words.core.types.language.W3WProprietaryLanguage
+import com.what3words.core.types.language.W3WRFC5646Language
 import com.what3words.core.types.options.W3WAutosuggestOptions
 import org.junit.Test
 
-class W3WApiTextDatasourceTest {
+class W3WApiTextDataSourceTest {
 
     private val fakeWhat3WordsV3Service = FakeWhat3WordsV3Service()
 
-    private val w3WApiTextDatasource = W3WApiTextDatasource(
+    private val w3WApiTextDatasource = W3WApiTextDataSource(
         fakeWhat3WordsV3Service,
         MappersFactory.providesConvertTo3waDtoToDomainMapper(),
         MappersFactory.providesConvertToCoordinatesResponseMapper(),
@@ -30,7 +30,7 @@ class W3WApiTextDatasourceTest {
     fun convertTo3wa_withInvalidCoordinates_returnsBadCoordinatesError() {
         val result = w3WApiTextDatasource.convertTo3wa(
             W3WCoordinates(-91.0, 181.0),
-            W3WLanguage("en", "en_GB")
+            W3WProprietaryLanguage("en", "en_GB")
         )
         assert(result is W3WResult.Failure)
         result as W3WResult.Failure
@@ -41,7 +41,7 @@ class W3WApiTextDatasourceTest {
     fun convertTo3wa_withValidCoordinates_returnsW3WAddress() {
         val result = w3WApiTextDatasource.convertTo3wa(
             W3WCoordinates(10.251020, 105.574460),
-            W3WLanguage("en", "en_GB")
+            W3WProprietaryLanguage("en", "en_GB")
         )
         assert(result is W3WResult.Success)
         result as W3WResult.Success
@@ -52,7 +52,7 @@ class W3WApiTextDatasourceTest {
     fun convertTo3wa_withValidCoordinatesAndRFC5646Language_returnsW3WAddress() {
         val result = w3WApiTextDatasource.convertTo3wa(
             W3WCoordinates(10.251020, 105.574460),
-            W3WLanguageRCF5646.EN_GB
+            W3WRFC5646Language.EN_GB
         )
         assert(result is W3WResult.Success)
         result as W3WResult.Success

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/extensions/W3WDomainToApiStringExtensionsTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/extensions/W3WDomainToApiStringExtensionsTest.kt
@@ -1,4 +1,4 @@
-package com.what3words.androidwrapper
+package com.what3words.androidwrapper.datasource.text.api.extensions
 
 import com.what3words.androidwrapper.datasource.text.api.extensions.W3WDomainToApiStringExtensions.toAPIString
 import com.what3words.core.types.domain.W3WCountry

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/AutosuggestResponseMapperTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/AutosuggestResponseMapperTest.kt
@@ -1,4 +1,4 @@
-package com.what3words.androidwrapper
+package com.what3words.androidwrapper.datasource.text.api.mapper
 
 import com.what3words.androidwrapper.datasource.text.api.dto.ErrorDto
 import com.what3words.androidwrapper.datasource.text.api.dto.SuggestionDto
@@ -79,31 +79,31 @@ class AutosuggestResponseMapperTest {
         assert(result.size == 3)
         assert(result[0].w3wAddress.address == "///index.home.raft")
         assert(result[0].w3wAddress.nearestPlace == "Bayswater, London")
-        assert(result[0].w3wAddress.language.code == "en")
+        assert(result[0].w3wAddress.language.w3wCode == "en")
         assert(result[0].w3wAddress.country.twoLetterCode == "GB")
         assert(result[0].w3wAddress.center == null)
         assert(result[0].w3wAddress.square == null)
-        assert(result[0].w3wAddress.language.locale == null)
+        assert(result[0].w3wAddress.language.w3wLocale == null)
         assert(result[0].distanceToFocus == null)
         assert(result[0].rank == 1)
 
         assert(result[1].w3wAddress.address == "///indexes.home.raft")
         assert(result[1].w3wAddress.nearestPlace == "Prosperity, West Virginia")
-        assert(result[1].w3wAddress.language.code == "en")
+        assert(result[1].w3wAddress.language.w3wCode == "en")
         assert(result[1].w3wAddress.country.twoLetterCode == "US")
         assert(result[1].w3wAddress.center == null)
         assert(result[1].w3wAddress.square == null)
-        assert(result[1].w3wAddress.language.locale == null)
+        assert(result[1].w3wAddress.language.w3wLocale == null)
         assert(result[1].distanceToFocus == null)
         assert(result[1].rank == 2)
 
         assert(result[2].w3wAddress.address == "///index.homes.raft")
         assert(result[2].w3wAddress.nearestPlace == "Greensboro, North Carolina")
-        assert(result[2].w3wAddress.language.code == "en")
+        assert(result[2].w3wAddress.language.w3wCode == "en")
         assert(result[2].w3wAddress.country.twoLetterCode == "US")
         assert(result[2].w3wAddress.center == null)
         assert(result[2].w3wAddress.square == null)
-        assert(result[2].w3wAddress.language.locale == null)
+        assert(result[2].w3wAddress.language.w3wLocale == null)
         assert(result[2].distanceToFocus == null)
         assert(result[2].rank == 3)
     }

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/ConvertTo3waResponseMapperTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/ConvertTo3waResponseMapperTest.kt
@@ -1,4 +1,4 @@
-package com.what3words.androidwrapper
+package com.what3words.androidwrapper.datasource.text.api.mapper
 
 import com.what3words.androidwrapper.datasource.text.api.dto.CoordinatesDto
 import com.what3words.androidwrapper.datasource.text.api.dto.SquareDto
@@ -41,8 +41,8 @@ class ConvertTo3waResponseMapperTest {
 
         // Assert
         assert(result.address == "///index.home.raft")
-        assert(result.language.code == "en")
-        assert(result.language.locale == null)
+        assert(result.language.w3wCode == "en")
+        assert(result.language.w3wLocale == null)
         assert(result.center?.lng == -0.203586)
         assert(result.center?.lat == 51.521251)
         assert(result.square?.southwest?.lng == -0.203607)

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/ConvertToCoordinatesResponseMapperTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/ConvertToCoordinatesResponseMapperTest.kt
@@ -1,4 +1,4 @@
-package com.what3words.androidwrapper
+package com.what3words.androidwrapper.datasource.text.api.mapper
 
 import com.what3words.androidwrapper.datasource.text.api.dto.CoordinatesDto
 import com.what3words.androidwrapper.datasource.text.api.dto.ErrorDto

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/ErrorDtoToDomainMapperTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/ErrorDtoToDomainMapperTest.kt
@@ -1,4 +1,4 @@
-package com.what3words.androidwrapper
+package com.what3words.androidwrapper.datasource.text.api.mapper
 
 import com.what3words.androidwrapper.datasource.text.api.dto.ErrorDto
 import com.what3words.androidwrapper.datasource.text.api.error.BadBoundingBoxError

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/GridSectionResponseMapperTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/GridSectionResponseMapperTest.kt
@@ -1,4 +1,4 @@
-package com.what3words.androidwrapper
+package com.what3words.androidwrapper.datasource.text.api.mapper
 
 import com.what3words.androidwrapper.datasource.text.api.dto.CoordinatesDto
 import com.what3words.androidwrapper.datasource.text.api.dto.ErrorDto
@@ -7,7 +7,6 @@ import com.what3words.androidwrapper.datasource.text.api.mappers.CoordinatesDtoT
 import com.what3words.androidwrapper.datasource.text.api.mappers.GridSectionResponseMapper
 import com.what3words.androidwrapper.datasource.text.api.mappers.LineDtoToDomainMapper
 import com.what3words.androidwrapper.datasource.text.api.response.GridSectionResponse
-import org.junit.Assert
 import org.junit.Test
 
 class GridSectionResponseMapperTest {

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/LanguageDtoToDomainMapperTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/LanguageDtoToDomainMapperTest.kt
@@ -1,8 +1,8 @@
-package com.what3words.androidwrapper
+package com.what3words.androidwrapper.datasource.text.api.mapper
 
 import com.what3words.androidwrapper.datasource.text.api.dto.LanguageDto
 import com.what3words.androidwrapper.datasource.text.api.mappers.LanguageDtoToDomainMapper
-import com.what3words.core.types.language.W3WLanguage
+import com.what3words.core.types.language.W3WProprietaryLanguage
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -31,11 +31,11 @@ class LanguageDtoToDomainMapperTest {
         )
 
         val expected = listOf(
-            W3WLanguage(
+            W3WProprietaryLanguage(
                 code = "en",
                 locale = "en_US"
             ),
-            W3WLanguage(
+            W3WProprietaryLanguage(
                 code = "en",
                 locale = "en_GB"
             )
@@ -56,7 +56,7 @@ class LanguageDtoToDomainMapperTest {
         )
 
         val expected = listOf(
-            W3WLanguage(
+            W3WProprietaryLanguage(
                 code = "vi",
                 locale = null
             )
@@ -78,7 +78,7 @@ class LanguageDtoToDomainMapperTest {
         )
 
         val expected = listOf(
-            W3WLanguage(
+            W3WProprietaryLanguage(
                 code = "vi",
                 locale = null
             )

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
         mavenCentral()
         // what3words android core library staging url
         maven {
-            url "https://s01.oss.sonatype.org/content/repositories/comwhat3words-1365"
+            url "https://s01.oss.sonatype.org/content/repositories/comwhat3words-1384"
         }
     }
 }


### PR DESCRIPTION
This PR includes the following changes:
- `W3WApiTextDatasource` has been renamed to `W3WApiTextDataSource` to align with the naming convention for `W3WTextDataSource` in the what3words core library.
- Code has been refactored to incorporate updates to the language structure in the what3words core library.