### PR TITLE
Update return type for W3WApiTextDataSource.convertToCoordinates method

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ class MainActivity : AppCompatActivity() {
                         Log.e("MainActivity", "Error: ${result.message}")
                     }
                     is W3WResult.Success -> {
-                        Log.d("MainActivity", "Coordinates: ${result.value.lat}, ${result.value.lng}")
+                        Log.d("MainActivity", "Coordinates: ${result.value.center.lat}, ${result.value.center.lng}")
                     }
                 }
             }
@@ -483,7 +483,7 @@ val result = textDataSource.convertToCoordinates(words) // Must run on backgroun
 Parameters: 
 - words: ```String```
 
-Return ```W3WResult<W3WCoordinates>```
+Return ```W3WResult<W3WAddress>```
 
 For more details and instructions, see [Convert to coordinates example](#converttocoordinates-example).
 <br><br>

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/W3WApiTextDataSource.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/W3WApiTextDataSource.kt
@@ -40,7 +40,7 @@ import com.what3words.javawrapper.request.SourceApi
 class W3WApiTextDataSource internal constructor(
     private val what3WordsV3Service: What3WordsV3Service,
     private val convertTo3waDtoToDomainMapper: Mapper<ConvertTo3waResponse, W3WAddress>,
-    private val convertToCoordinatesResponseMapper: Mapper<ConvertToCoordinatesResponse, W3WCoordinates>,
+    private val convertToCoordinatesResponseMapper: Mapper<ConvertToCoordinatesResponse, W3WAddress>,
     private val autosuggestResponseMapper: Mapper<AutosuggestResponse, List<W3WSuggestion>>,
     private val availableLanguagesResponseMapper: Mapper<AvailableLanguagesResponse, Set<W3WProprietaryLanguage>>,
     private val gridSectionResponseMapper: Mapper<GridSectionResponse, W3WGridSection>
@@ -78,7 +78,7 @@ class W3WApiTextDataSource internal constructor(
      * @return A [W3WResult] instance containing the what3words coordinates.
      */
     @Throws(InterruptedException::class)
-    override fun convertToCoordinates(words: String): W3WResult<W3WCoordinates> {
+    override fun convertToCoordinates(words: String): W3WResult<W3WAddress> {
         return executeApiRequestAndHandleResponse(convertToCoordinatesResponseMapper) {
             what3WordsV3Service.convertToCoordinates(
                 address = words

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/di/MappersFactory.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/di/MappersFactory.kt
@@ -39,7 +39,10 @@ internal object MappersFactory {
     }
 
     private val convertToCoordinatesResponseMapper: ConvertToCoordinatesResponseMapper by lazy {
-        ConvertToCoordinatesResponseMapper(coordinatesDtoToDomainMapper = coordinatesDtoToDomainMapper)
+        ConvertToCoordinatesResponseMapper(
+            coordinatesDtoToDomainMapper = coordinatesDtoToDomainMapper,
+            squareDtoToDomainMapper = squareDtoToDomainMapper
+        )
     }
 
     private val convertTo3waDtoToDomainMapper: ConvertTo3waResponseMapper by lazy {
@@ -75,7 +78,7 @@ internal object MappersFactory {
     fun providesAutosuggestResponseMapper(): Mapper<AutosuggestResponse, List<W3WSuggestion>> =
         autosuggestResponseMapper
 
-    fun providesConvertToCoordinatesResponseMapper(): Mapper<ConvertToCoordinatesResponse, W3WCoordinates> =
+    fun providesConvertToCoordinatesResponseMapper(): Mapper<ConvertToCoordinatesResponse, W3WAddress> =
         convertToCoordinatesResponseMapper
 
     fun providesConvertTo3waDtoToDomainMapper(): Mapper<ConvertTo3waResponse, W3WAddress> =

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/ConvertToCoordinatesResponseMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/ConvertToCoordinatesResponseMapper.kt
@@ -2,16 +2,34 @@ package com.what3words.androidwrapper.datasource.text.api.mappers
 
 import com.what3words.androidwrapper.common.Mapper
 import com.what3words.androidwrapper.datasource.text.api.dto.CoordinatesDto
+import com.what3words.androidwrapper.datasource.text.api.dto.SquareDto
 import com.what3words.androidwrapper.datasource.text.api.response.ConvertToCoordinatesResponse
+import com.what3words.core.types.domain.W3WAddress
+import com.what3words.core.types.domain.W3WCountry
 import com.what3words.core.types.geometry.W3WCoordinates
+import com.what3words.core.types.geometry.W3WRectangle
+import com.what3words.core.types.language.W3WProprietaryLanguage
 
 internal class ConvertToCoordinatesResponseMapper(
     private val coordinatesDtoToDomainMapper: Mapper<CoordinatesDto, W3WCoordinates>,
-) : Mapper<ConvertToCoordinatesResponse, W3WCoordinates> {
-    override fun mapFrom(from: ConvertToCoordinatesResponse): W3WCoordinates {
+    private val squareDtoToDomainMapper: Mapper<SquareDto, W3WRectangle>
+) : Mapper<ConvertToCoordinatesResponse, W3WAddress> {
+    override fun mapFrom(from: ConvertToCoordinatesResponse): W3WAddress {
         return with(from) {
-            coordinates?.let { coordinatesDtoToDomainMapper.mapFrom(it) }
-                ?: throw NullPointerException("Coordinates property cannot be null")
+            val words = words ?: throw NullPointerException("Words property cannot be null")
+            val center = coordinates?.let { coordinatesDtoToDomainMapper.mapFrom(it) }
+                ?: throw NullPointerException("Center coordinates property cannot be null")
+            val square = square?.let { squareDtoToDomainMapper.mapFrom(it) }
+                ?: throw NullPointerException("Square property cannot be null")
+            val language = language?.let {
+                W3WProprietaryLanguage(code = it, locale = locale)
+            } ?: throw NullPointerException("Language property cannot be null")
+            val country = country?.let { W3WCountry(twoLetterCode = it) }
+                ?: throw NullPointerException("Country property cannot be null")
+            val nearestPlace =
+                nearestPlace ?: throw NullPointerException("Nearest place property cannot be null")
+
+            W3WAddress(words, center, square, language, country, nearestPlace)
         }
     }
 }

--- a/lib/src/main/java/com/what3words/androidwrapper/helpers/AutosuggestHelper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/helpers/AutosuggestHelper.kt
@@ -190,7 +190,7 @@ class AutosuggestHelper(
                         val newSuggestion = W3WSuggestion(
                             w3wAddress = W3WAddress(
                                 words = word,
-                                center = res.value,
+                                center = res.value.center,
                                 square = suggestion.w3wAddress.square,
                                 language = suggestion.w3wAddress.language,
                                 country = suggestion.w3wAddress.country,

--- a/lib/src/test/java/com/what3words/androidwrapper/AutosuggestHelperTests.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/AutosuggestHelperTests.kt
@@ -10,6 +10,7 @@ import com.what3words.androidwrapper.datasource.voice.mappers.SuggestionMapper
 import com.what3words.androidwrapper.helpers.AutosuggestHelper
 import com.what3words.core.types.common.W3WError
 import com.what3words.core.types.common.W3WResult
+import com.what3words.core.types.domain.W3WAddress
 import com.what3words.core.types.domain.W3WCountry
 import com.what3words.core.types.domain.W3WSuggestion
 import com.what3words.core.types.geometry.W3WCoordinates
@@ -368,11 +369,18 @@ class AutosuggestHelperTests {
             // given
             val suggestion = mockk<W3WSuggestion>()
             val coordinates = mockk<W3WCoordinates>()
+            val address = mockk<W3WAddress>()
 
             every {
                 suggestion.w3wAddress.address
             } answers {
                 "///index.home.raft"
+            }
+
+            every {
+                address.center
+            } answers {
+                coordinates
             }
 
             every {
@@ -432,7 +440,7 @@ class AutosuggestHelperTests {
             every {
                 dataSource.convertToCoordinates(any())
             } answers {
-                W3WResult.Success(coordinates)
+                W3WResult.Success(address)
             }
 
 

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/W3WApiTextDataSourceTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/W3WApiTextDataSourceTest.kt
@@ -64,8 +64,8 @@ class W3WApiTextDataSourceTest {
         val result = w3WApiTextDataSource.convertToCoordinates("country.square.words")
         assert(result is W3WResult.Success)
         result as W3WResult.Success
-        assert(result.value.lat == fakeWhat3WordsV3Service.coordinatesDto.lat)
-        assert(result.value.lng == fakeWhat3WordsV3Service.coordinatesDto.lng)
+        assert(result.value.center?.lat == fakeWhat3WordsV3Service.coordinatesDto.lat)
+        assert(result.value.center?.lng == fakeWhat3WordsV3Service.coordinatesDto.lng)
     }
 
     @Test

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/ConvertToCoordinatesResponseMapperTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/ConvertToCoordinatesResponseMapperTest.kt
@@ -5,14 +5,16 @@ import com.what3words.androidwrapper.datasource.text.api.dto.ErrorDto
 import com.what3words.androidwrapper.datasource.text.api.dto.SquareDto
 import com.what3words.androidwrapper.datasource.text.api.mappers.ConvertToCoordinatesResponseMapper
 import com.what3words.androidwrapper.datasource.text.api.mappers.CoordinatesDtoToDomainMapper
+import com.what3words.androidwrapper.datasource.text.api.mappers.SquareDtoToDomainMapper
 import com.what3words.androidwrapper.datasource.text.api.response.ConvertToCoordinatesResponse
 import org.junit.Assert
 import org.junit.Test
 
 class ConvertToCoordinatesResponseMapperTest {
 
+    private val coordinatesDtoToDomainMapper = CoordinatesDtoToDomainMapper()
     private val convertToCoordinatesResponseMapper =
-        ConvertToCoordinatesResponseMapper(CoordinatesDtoToDomainMapper())
+        ConvertToCoordinatesResponseMapper(coordinatesDtoToDomainMapper, SquareDtoToDomainMapper(coordinatesDtoToDomainMapper))
 
     @Test
     fun `mapFrom should return W3WCoordinates`() {
@@ -25,7 +27,7 @@ class ConvertToCoordinatesResponseMapperTest {
                 CoordinatesDto(lng = -0.203607, lat = 51.521238),
                 CoordinatesDto(lng = -0.203564, lat = 51.521265)
             ),
-            country = null,
+            country = "GB",
             nearestPlace = "Bayswater, London",
             locale = null,
             error = null,
@@ -36,8 +38,8 @@ class ConvertToCoordinatesResponseMapperTest {
         val result = convertToCoordinatesResponseMapper.mapFrom(convertToCoordinatesResponse)
 
         // Assert
-        assert(result.lat == 51.521251)
-        assert(result.lng == -0.203586)
+        assert(result.center?.lat == 51.521251)
+        assert(result.center?.lng == -0.203586)
     }
 
     @Test

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/fake/FakeWhat3WordsV3Service.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/fake/FakeWhat3WordsV3Service.kt
@@ -85,7 +85,7 @@ internal class FakeWhat3WordsV3Service : What3WordsV3Service {
                     squareDto,
                     "",
                     coordinatesDto,
-                    null,
+                    w3w,
                     "",
                     "",
                     "",


### PR DESCRIPTION
In this PR I updated the return type for the W3WTextDataSource `converToCoordinates` method in the core library from `W3WResult<W3WCoordinates>` to `W3WResult<W3WAddress>`