### PR TITLE
Update W3WProprietaryLanguage to include nativeName and name properties

### DIFF
--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/AutosuggestResponseMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/AutosuggestResponseMapper.kt
@@ -31,7 +31,12 @@ internal class AutosuggestResponseMapper(
                     square = suggestion.square?.let {
                         squareDtoToDomainMapper.mapFrom(it)
                     },
-                    language = W3WProprietaryLanguage(suggestion.language, suggestion.locale),
+                    language = W3WProprietaryLanguage(
+                        code = suggestion.language,
+                        locale = suggestion.locale,
+                        name = null,
+                        nativeName = null
+                    ),
                     country = W3WCountry(suggestion.country)
                 ),
                 distanceToFocus = suggestion.distanceToFocusKm?.toDouble()?.let(::W3WDistance),

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/ConvertTo3waResponseMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/ConvertTo3waResponseMapper.kt
@@ -22,7 +22,7 @@ internal class ConvertTo3waResponseMapper(
             val square = square?.let { squareDtoToDomainMapper.mapFrom(it) }
                 ?: throw NullPointerException("Square property cannot be null")
             val language = language?.let {
-                W3WProprietaryLanguage(code = it, locale = locale)
+                W3WProprietaryLanguage(code = it, locale = locale, name = null, nativeName = null)
             } ?: throw NullPointerException("Language property cannot be null")
             val country = country?.let { W3WCountry(twoLetterCode = it) }
                 ?: throw NullPointerException("Country property cannot be null")

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/ConvertToCoordinatesResponseMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/ConvertToCoordinatesResponseMapper.kt
@@ -22,7 +22,7 @@ internal class ConvertToCoordinatesResponseMapper(
             val square = square?.let { squareDtoToDomainMapper.mapFrom(it) }
                 ?: throw NullPointerException("Square property cannot be null")
             val language = language?.let {
-                W3WProprietaryLanguage(code = it, locale = locale)
+                W3WProprietaryLanguage(code = it, locale = locale, name = null, nativeName = null)
             } ?: throw NullPointerException("Language property cannot be null")
             val country = country?.let { W3WCountry(twoLetterCode = it) }
                 ?: throw NullPointerException("Country property cannot be null")

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/LanguageDtoToDomainMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/text/api/mappers/LanguageDtoToDomainMapper.kt
@@ -7,19 +7,22 @@ import com.what3words.core.types.language.W3WProprietaryLanguage
 internal class LanguageDtoToDomainMapper : Mapper<LanguageDto, List<W3WProprietaryLanguage>> {
     override fun mapFrom(from: LanguageDto): List<W3WProprietaryLanguage> {
         return buildList {
-            if (from.locales.isNullOrEmpty()) {
-                add(
-                    W3WProprietaryLanguage(
-                        code = from.code, locale = null
-                    )
+            add(
+                W3WProprietaryLanguage(
+                    code = from.code,
+                    locale = null,
+                    name = from.name,
+                    nativeName = from.nativeName
                 )
-            } else {
-                addAll(from.locales.map { localeDto ->
-                    W3WProprietaryLanguage(
-                        code = from.code, locale = localeDto.code
-                    )
-                })
-            }
+            )
+            from.locales?.map {
+                W3WProprietaryLanguage(
+                    code = from.code,
+                    locale = it.code,
+                    name = it.name,
+                    nativeName = it.nativeName
+                )
+            }?.let(::addAll)
         }
     }
 }

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/voice/W3WApiVoiceDataSource.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/voice/W3WApiVoiceDataSource.kt
@@ -60,7 +60,7 @@ class W3WApiVoiceDataSource internal constructor(
 
                     is W3WVoiceClient.RecognitionStatus.Error -> {
                         val voiceError = status.error
-                        onResult(W3WResult.Failure(voiceError.message, voiceError))
+                        onResult(W3WResult.Failure(voiceError, voiceError.message))
                     }
                 }
             }

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/voice/mappers/SuggestionMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/voice/mappers/SuggestionMapper.kt
@@ -15,7 +15,12 @@ class SuggestionMapper: Mapper<Suggestion, W3WSuggestion> {
                 words = from.words,
                 center = null,
                 square = null,
-                language = W3WProprietaryLanguage(from.language, from.locale),
+                language = W3WProprietaryLanguage(
+                    code = from.language,
+                    locale = from.locale,
+                    name = null,
+                    nativeName = null
+                ),
                 country = W3WCountry(from.country),
                 nearestPlace = from.nearestPlace
             ),

--- a/lib/src/main/java/com/what3words/androidwrapper/datasource/voice/mappers/SuggestionWithCoordinatesMapper.kt
+++ b/lib/src/main/java/com/what3words/androidwrapper/datasource/voice/mappers/SuggestionWithCoordinatesMapper.kt
@@ -28,7 +28,12 @@ class SuggestionWithCoordinatesMapper : Mapper<SuggestionWithCoordinates, W3WSug
                         )
                     )
                 },
-                language = W3WProprietaryLanguage(from.language, from.locale),
+                language = W3WProprietaryLanguage(
+                    code = from.language,
+                    locale = from.locale,
+                    name = null,
+                    nativeName = null
+                ),
                 country = W3WCountry(from.country),
                 nearestPlace = from.nearestPlace
             ),

--- a/lib/src/test/java/com/what3words/androidwrapper/AutosuggestHelperTests.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/AutosuggestHelperTests.kt
@@ -259,8 +259,8 @@ class AutosuggestHelperTests {
             val error = InvalidKeyError("invalid_key", "Invalid key")
             val failureResult =
                 W3WResult.Failure<List<W3WSuggestion>>(
-                    "Error",
-                    error
+                    error,
+                    "Error"
                 )
 
             every {
@@ -295,8 +295,7 @@ class AutosuggestHelperTests {
             val error = InvalidKeyError("invalid_key", "Invalid key")
             val failureResult =
                 W3WResult.Failure<List<W3WSuggestion>>(
-                    "Error",
-                    error
+                    error,"Error"
                 )
 
             every {
@@ -512,7 +511,7 @@ class AutosuggestHelperTests {
             every {
                 dataSource.convertToCoordinates("index.home.raft")
             } answers {
-                W3WResult.Failure("Bad word", error)
+                W3WResult.Failure(error,"Bad word")
             }
 
             every {

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/W3WApiTextDataSourceTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/W3WApiTextDataSourceTest.kt
@@ -30,7 +30,7 @@ class W3WApiTextDataSourceTest {
     fun convertTo3wa_withInvalidCoordinates_returnsBadCoordinatesError() {
         val result = w3WApiTextDataSource.convertTo3wa(
             W3WCoordinates(-91.0, 181.0),
-            W3WProprietaryLanguage("en", "en_GB")
+            W3WProprietaryLanguage("en", "en_GB", "English", "English")
         )
         assert(result is W3WResult.Failure)
         result as W3WResult.Failure
@@ -41,7 +41,7 @@ class W3WApiTextDataSourceTest {
     fun convertTo3wa_withValidCoordinates_returnsW3WAddress() {
         val result = w3WApiTextDataSource.convertTo3wa(
             W3WCoordinates(10.251020, 105.574460),
-            W3WProprietaryLanguage("en", "en_GB")
+            W3WProprietaryLanguage("en", "en_GB", name = null, nativeName = null)
         )
         assert(result is W3WResult.Success)
         result as W3WResult.Success

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/LanguageDtoToDomainMapperTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/text/api/mapper/LanguageDtoToDomainMapperTest.kt
@@ -33,11 +33,21 @@ class LanguageDtoToDomainMapperTest {
         val expected = listOf(
             W3WProprietaryLanguage(
                 code = "en",
-                locale = "en_US"
+                locale = null,
+                name = "English",
+                nativeName = "English",
             ),
             W3WProprietaryLanguage(
                 code = "en",
-                locale = "en_GB"
+                locale = "en_US",
+                name = "United States",
+                nativeName = "United States"
+            ),
+            W3WProprietaryLanguage(
+                code = "en",
+                locale = "en_GB",
+                name = "United Kingdom",
+                nativeName = "United Kingdom"
             )
         )
 
@@ -58,7 +68,9 @@ class LanguageDtoToDomainMapperTest {
         val expected = listOf(
             W3WProprietaryLanguage(
                 code = "vi",
-                locale = null
+                locale = null,
+                name = "Vietnamese",
+                nativeName = "Tiếng Việt"
             )
         )
 
@@ -80,7 +92,9 @@ class LanguageDtoToDomainMapperTest {
         val expected = listOf(
             W3WProprietaryLanguage(
                 code = "vi",
-                locale = null
+                locale = null,
+                name = "Vietnamese",
+                nativeName = "Tiếng Việt"
             )
         )
 


### PR DESCRIPTION
In this PR, I made the following changes 
- Update `W3WProprietaryLanguage` instances to include `nativeName` and `name` properties. 
- Revised `LanguageDtoToDomainMapper` 
- Updated W3WFailure types