### PR TITLE
Migrate to remote version catalog and AGP 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,16 @@ commands:
     description: Restore cache, config gradlew, download dependencies and save cache
     steps:
       - restore_cache:
-          key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "lib/build.gradle.kts" }}
+          key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum "lib/build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
           name: Set up library dependencies
           command: |
             ./gradlew wrapper
-            ./gradlew lib:androidDependencies
+            ./gradlew lib:dependencies
       - save_cache:
           paths:
             - ~/.gradle
-          key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "lib/build.gradle.kts" }}
+          key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum "lib/build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 jobs:
   android-test:
     executor:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,17 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    dependencies {
-        classpath("org.jacoco:org.jacoco.core:0.8.7")
-        classpath("com.android.tools.build:gradle:8.5.0")
-    }
+plugins {
+    alias(libs.plugins.gradle.ktlint)
+    alias(libs.plugins.sonarqube) apply false
+    alias(libs.plugins.android.library) apply false
 }
 
-plugins {
-    id("org.jetbrains.kotlin.android") version "1.8.20" apply false
-    id("org.jlleitschuh.gradle.ktlint") version "10.1.0" apply true
-    id("org.sonarqube") version "3.3" apply false
-    id("com.android.library") version "8.5.0" apply false
-    id("com.autonomousapps.dependency-analysis") version "1.20.0" apply true
+allprojects {
+    configurations.all {
+        resolutionStrategy.cacheChangingModulesFor(0, "seconds")
+    }
 }
 
 tasks.register<Delete>("clean").configure {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 # Library version
-LIBRARY_VERSION=4.0.3
+LIBRARY_VERSION=4.1.0
 BASE_TEXT_API_ENDPOINT=https://api.what3words.com
 TEXT_API_VERSION=v3
 BASE_VOICE_API_ENDPOINT=voiceapi.what3words.com

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -10,21 +10,26 @@ ext {
     ]
 }
 
+def versionCatalog = rootProject.extensions
+        .getByType(VersionCatalogsExtension)
+        .named("libs")
+
 jacoco {
-    toolVersion = '0.8.7'
+    toolVersion = versionCatalog.findVersion("jacoco-core").get().requiredVersion
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     jacoco.includeNoLocationClasses = true
     // https://github.com/gradle/gradle/issues/5184#issuecomment-457865951
     jacoco.excludes = ['jdk.internal.*']
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     finalizedBy jacocoTestReport // report is always generated after tests run
 }
 
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
+tasks.register('jacocoTestReport', JacocoReport) {
+    dependsOn['testDebugUnitTest']
     group = "Reporting"
     description = "Generate Jacoco coverage reports for Debug build"
 
@@ -33,8 +38,9 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
         csv.required = false
     }
 
-    def javaTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug/classes", excludes: coverageExclusions)
-    def kotlinTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: coverageExclusions)
+    def buildDirectory = layout.buildDirectory
+    def javaTree = fileTree(dir: buildDirectory.dir("intermediates/javac/debug/classes").get().asFile, excludes: coverageExclusions)
+    def kotlinTree = fileTree(dir: buildDirectory.dir("tmp/kotlin-classes/debug").get().asFile, excludes: coverageExclusions)
 
     def mainSrc = "/src/main/java"
 
@@ -42,5 +48,5 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     sourceDirectories.from = files([mainSrc])
     classDirectories.from = files([javaTree, kotlinTree])
 
-    executionData.from = files("${buildDir}/jacoco/testDebugUnitTest.exec")
+    executionData.from = files(buildDirectory.file("jacoco/testDebugUnitTest.exec").get().asFile)
 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,13 +1,12 @@
 import java.net.*
 
 plugins {
-    id("com.android.library")
-    id("kotlin-android")
-    id("com.avast.gradle.docker-compose") version "0.14.3"
-    id("org.sonarqube")
+    alias(libs.plugins.android.library)
+    id("com.avast.gradle.docker-compose") version "0.17.21"
+    alias(libs.plugins.sonarqube)
     id("maven-publish")
     id("signing")
-    id("org.jetbrains.dokka") version "1.5.0"
+    alias(libs.plugins.dokka)
 }
 
 apply(from = "../jacoco.gradle")
@@ -24,14 +23,10 @@ version =
     if (isSnapshotRelease) "${findProperty("LIBRARY_VERSION")}-SNAPSHOT" else "${findProperty("LIBRARY_VERSION")}"
 
 android {
-    compileSdk = 34
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
+    compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
-        minSdk = 21
+        minSdk = libs.versions.minSdk.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -60,8 +55,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.toVersion(libs.versions.jvmToolchain.get())
+        targetCompatibility = JavaVersion.toVersion(libs.versions.jvmToolchain.get())
     }
 
     buildTypes {
@@ -91,41 +86,41 @@ android {
 
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation(libs.androidx.core.ktx)
     // kotlin
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     // w3w java wrapper
-    api("com.what3words:w3w-java-wrapper:3.1.22")
+    api(libs.w3w.java.wrapper)
 
     // w3w core library
-    api("com.what3words:w3w-core-android:1.2.0")
+    api(libs.w3w.core.multiplatform)
 
     // retrofit
-    implementation("com.squareup.retrofit2:retrofit:2.11.0")
-    implementation("com.squareup.retrofit2:converter-gson:2.11.0")
-    implementation("com.squareup.retrofit2:converter-moshi:2.5.0")
-    implementation("com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2")
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.converterGson)
+    implementation(libs.retrofit.converterMoshi)
+    implementation(libs.retrofit.kotlinCoroutinesAdapter)
 
 
     // testing
-    testImplementation("junit:junit:4.13.2")
-    testRuntimeOnly("androidx.test:core:1.6.1")
-    testImplementation("com.google.truth:truth:1.4.2")
-    testImplementation("io.mockk:mockk:1.12.1")
-    testImplementation("androidx.arch.core:core-testing:2.2.0")
-    testImplementation("org.robolectric:robolectric:4.11.1")
-    testImplementation("org.json:json:20230618")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    testImplementation(libs.junit)
+    testRuntimeOnly(libs.androidx.test.core)
+    testImplementation(libs.truth)
+    testImplementation(libs.mockk)
+    testImplementation(libs.androidx.arch.core.testing)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.org.json)
+    testImplementation(libs.okhttp.mockwebserver)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.espresso.core)
 
     // Moshi
-    implementation("com.squareup.moshi:moshi:1.15.0")
-    implementation("com.squareup.moshi:moshi-kotlin:1.15.0")
-    annotationProcessor("com.squareup.moshi:moshi-kotlin-codegen:1.8.0")
+    implementation(libs.moshi)
+    implementation(libs.moshi.kotlin)
+    annotationProcessor(libs.moshi.kotlin.codegen)
 }
 
 //region publishing
@@ -168,7 +163,7 @@ publishing {
                         group = JavaBasePlugin.DOCUMENTATION_GROUP
                         description = "Assembles Kotlin docs with Dokka into a Javadoc jar"
                         archiveClassifier.set("javadoc")
-                        from(tasks.named("dokkaHtml"))
+                        from(tasks.named("dokkaGeneratePublicationHtml"))
 
                         // Each archive name should be distinct, to avoid implicit dependency issues.
                         // We use the same format as the sources Jar tasks.

--- a/lib/src/test/java/com/what3words/androidwrapper/AutosuggestHelperTests.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/AutosuggestHelperTests.kt
@@ -28,7 +28,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -94,7 +94,7 @@ class AutosuggestHelperTests {
     }
 
     @Test
-    fun `invalid 3wa return empty list`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `invalid 3wa return empty list`() = runTest(coroutinesTestRule.testDispatcher) {
         // given
         val list = emptyList<W3WSuggestion>()
 
@@ -107,7 +107,7 @@ class AutosuggestHelperTests {
     }
 
     @Test
-    fun `valid 3wa returns suggestions`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `valid 3wa returns suggestions`() = runTest(coroutinesTestRule.testDispatcher) {
         // given
         val helper = AutosuggestHelper(dataSource, coroutinesTestRule.testDispatcherProvider)
         val suggestionsJson =
@@ -146,7 +146,7 @@ class AutosuggestHelperTests {
 
     @Test
     fun `did you mean 3wa returns suggestions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
 
             every {
@@ -182,7 +182,7 @@ class AutosuggestHelperTests {
 
     @Test
     fun `did you mean 3wa returns suggestions with capital letters`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             every {
                 dataSource.autosuggest("star.words.f", null)
@@ -217,7 +217,7 @@ class AutosuggestHelperTests {
 
     @Test
     fun `allowFlexibleDelimiters is true returns suggestions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             helper.allowFlexibleDelimiters(true)
 
@@ -255,7 +255,7 @@ class AutosuggestHelperTests {
 
     @Test
     fun `valid 3wa returns ApiError and callback is set`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
 
             val error = InvalidKeyError("invalid_key", "Invalid key")
@@ -292,7 +292,7 @@ class AutosuggestHelperTests {
 
     @Test
     fun `valid 3wa returns ApiError and callback is not set`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val error = InvalidKeyError("invalid_key", "Invalid key")
             val failureResult =
@@ -327,7 +327,7 @@ class AutosuggestHelperTests {
 
     @Test
     fun `selected suggestion without coordinates`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val suggestion = mockk<W3WSuggestion>()
 
@@ -366,7 +366,7 @@ class AutosuggestHelperTests {
 
     @Test
     fun `selected suggestion with coordinates`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val suggestion = mockk<W3WSuggestion>()
             val coordinates = mockk<W3WCoordinates>()
@@ -480,7 +480,7 @@ class AutosuggestHelperTests {
 
     @Test
     fun `selectedWithCoordinates returns error`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val suggestion = mockk<W3WSuggestion>()
             val coordinates = mockk<W3WCoordinates>()
@@ -549,7 +549,7 @@ class AutosuggestHelperTests {
 
     @Test
     fun `filters are set expect autosuggestBuilder filters to be called`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             val focus = W3WCoordinates(51.2, 0.234)
             val boundingBox = W3WRectangle(focus, focus)
             val polygon = W3WPolygon(listOf(focus, focus, focus))

--- a/lib/src/test/java/com/what3words/androidwrapper/CoroutineTestRule.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/CoroutineTestRule.kt
@@ -4,14 +4,15 @@ import com.what3words.androidwrapper.helpers.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
-class CoroutineTestRule(val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()) :
+class CoroutineTestRule(val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()) :
     TestWatcher() {
 
     val testDispatcherProvider = object : DispatcherProvider {
@@ -29,6 +30,5 @@ class CoroutineTestRule(val testDispatcher: TestCoroutineDispatcher = TestCorout
     override fun finished(description: Description?) {
         super.finished(description)
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 }

--- a/lib/src/test/java/com/what3words/androidwrapper/VoiceApiTests.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/VoiceApiTests.kt
@@ -14,7 +14,6 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.test.runBlockingTest
 import okhttp3.OkHttpClient
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener

--- a/lib/src/test/java/com/what3words/androidwrapper/VoiceBuilderTests.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/VoiceBuilderTests.kt
@@ -23,7 +23,7 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import okhttp3.WebSocket
 import org.junit.Before
 import org.junit.Rule
@@ -107,7 +107,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `startListening then force stopListening`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -136,7 +136,7 @@ class VoiceBuilderTests {
         }
 
     @Test
-    fun `startListening then error occurs`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `startListening then error occurs`() = runTest(coroutinesTestRule.testDispatcher) {
         // given
         val what3WordsV3 = What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
         val builder = what3WordsV3.autosuggest(microphone, "en")
@@ -165,7 +165,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `startListening then returns suggestions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -200,7 +200,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `focus is set to VoiceBuilder autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -219,7 +219,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `focus is set with nFocusResults to VoiceBuilder autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -239,7 +239,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `nResults is set to VoiceBuilder autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -257,7 +257,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `clipToCountry is set to VoiceBuilder autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -275,7 +275,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `clipToCircle is set without radius to VoiceBuilder autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -294,7 +294,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `clipToCircle is set with radius to VoiceBuilder autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -313,7 +313,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `clipToBoundingBox is set to VoiceBuilder autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val expectedUrl =
                 "${BASE_URL}${URL_WITHOUT_COORDINATES}?voice-language=en&clip-to-bounding-box=51.1,-0.152,51.1,-0.152"
@@ -340,7 +340,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `clipToPolygon is set to VoiceBuilder autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -370,7 +370,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `updateAutosuggestOptions in VoiceBuilder`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggest(microphone, "en")
@@ -406,7 +406,7 @@ class VoiceBuilderTests {
 
     @Test
     fun `custom VoiceApi URL`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val textCustomUrl = "http://custom.text.url/"
             val voiceCustomUrl = "wss://custom.voice.url/"

--- a/lib/src/test/java/com/what3words/androidwrapper/VoiceBuilderWithCoordinatesTests.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/VoiceBuilderWithCoordinatesTests.kt
@@ -23,7 +23,7 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import okhttp3.WebSocket
 import org.junit.Before
 import org.junit.Rule
@@ -115,7 +115,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `startListening then force stopListening`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -154,7 +154,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `startListening then error occurs`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -193,7 +193,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `startListening then returns suggestions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -238,7 +238,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `focus is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -257,7 +257,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `focus is set with nFocusResults to VoiceBuilderWithCoordinates autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -277,7 +277,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `nResults is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -295,7 +295,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `clipToCountry is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -313,7 +313,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `clipToCircle is set without radius to VoiceBuilderWithCoordinates autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -332,7 +332,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `clipToCircle is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -351,7 +351,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `clipToBoundingBox is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -376,7 +376,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `clipToPolygon is set to VoiceBuilderWithCoordinates autosuggestOptions`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
@@ -406,7 +406,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `updateAutosuggestOptions in VoiceBuilderWithCoordinates`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             val what3WordsV3 =
                 What3WordsV3("key", voiceApi, coroutinesTestRule.testDispatcherProvider)
             val builder = what3WordsV3.autosuggestWithCoordinates(microphone, "en")
@@ -442,7 +442,7 @@ class VoiceBuilderWithCoordinatesTests {
 
     @Test
     fun `custom VoiceApi URL`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+        runTest(coroutinesTestRule.testDispatcher) {
             // given
             val textCustomUrl = "http://custom.text.url/"
             val voiceCustomUrl = "wss://custom.voice.url/"

--- a/lib/src/test/java/com/what3words/androidwrapper/datasource/voice/W3WApiVoiceDataSourceTest.kt
+++ b/lib/src/test/java/com/what3words/androidwrapper/datasource/voice/W3WApiVoiceDataSourceTest.kt
@@ -16,7 +16,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,9 +10,19 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(
-            "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-        )
+        mavenLocal()
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
+    }
+    versionCatalogs {
+        create("libs") {
+            from("com.what3words:android-version-catalog:2026.06.01-SNAPSHOT")
+
+            // minSdk differs from the remote catalog (25); pin to this project's value.
+            version("minSdk", "21")
+
+            // Libraries not present in the remote catalog.
+            library("w3w-java-wrapper", "com.what3words:w3w-java-wrapper:3.1.22")
+        }
     }
 }
 

--- a/sonarqube.gradle
+++ b/sonarqube.gradle
@@ -6,14 +6,12 @@ sonarqube {
         property "sonar.projectKey", "what3words_w3w-android-wrapper"
         property "sonar.organization", "what3words"
         property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.tests", "src/test/java"
-        property "sonar.test.inclusions", "**/*Test*/**"
         property "sonar.sourceEncoding", "UTF-8"
-        property "sonar.sources", "src/main/java"
-        property "sonar.exclusions", '**/*Test*/**,' +
-                'build/**' +
+        // Source and test directories are auto-detected from the Android Gradle
+        // source sets by the SonarQube plugin; configuring them manually causes
+        // files to be indexed as both main and test sources.
+        property "sonar.exclusions", 'build/**,' +
                 '*.json,' +
-                '**/*test*/**,' +
                 '**/.gradle/**,' +
                 '**/R.class'
         property "sonar.java.coveragePlugin", "jacoco"


### PR DESCRIPTION
Consume the shared what3words remote version catalog (android-version-catalog:2026.06.01) with local overrides for minSdk and libraries absent from the catalog. Upgrade to AGP 9.1.0 / Gradle 9.3.1 and migrate deprecated kotlinx-coroutines-test APIs (runBlockingTest/TestCoroutineDispatcher) to runTest/UnconfinedTestDispatcher.